### PR TITLE
Enhance mindmap layout

### DIFF
--- a/client/src/data/mindmap-data.ts
+++ b/client/src/data/mindmap-data.ts
@@ -309,7 +309,6 @@ export const mindMapNodes: MindMapNode[] = [
   { id: "gMEnphVIJM71", name: "Introduces weight decay", parentId: "vo8mF9JfowCG" },
   
   // Regularization
-  { id: "n5YmXLaYY8WP", name: "Regularization Techniques", parentId: "yq1G2-Rxt0Qn" },
   { id: "A7Dn_kfy-C5D", name: "Weight Decay", parentId: "n5YmXLaYY8WP" },
   { id: "cbZmF-G6T.7O", name: "Dropout", parentId: "n5YmXLaYY8WP" },
   { id: "cC8mD-mO99Da", name: "Gradient Clipping", parentId: "n5YmXLaYY8WP" },

--- a/client/src/pages/RoadmapPage.tsx
+++ b/client/src/pages/RoadmapPage.tsx
@@ -53,6 +53,7 @@ const categoryColors: Record<string, string> = {
 interface CustomNodeData {
   label: string
   isCompleted: boolean
+  completionRatio: number  // 0–1; topics: 0 or 1; categories: fraction of subtree done
   onToggle: () => void
   category: string
   level: number
@@ -74,6 +75,7 @@ function RootNode({ data }: { data: CustomNodeData }) {
 function CategoryNode({ data }: { data: CustomNodeData }) {
   const color = categoryColors[data.category] ?? '#6b7280'
   const isLeft = data.side === 'left'
+  const ratio = data.completionRatio
   return (
     <>
       <Handle
@@ -83,7 +85,13 @@ function CategoryNode({ data }: { data: CustomNodeData }) {
       />
       <div
         className="px-4 py-1.5 rounded-full font-bold text-sm text-white shadow-md select-none min-w-[100px] text-center"
-        style={{ backgroundColor: color }}
+        style={{
+          backgroundColor: color,
+          filter: `grayscale(${(1 - ratio) * 100}%)`,
+          opacity: 0.3 + ratio * 0.7,
+          boxShadow: ratio > 0 ? `0 0 ${Math.round(ratio * 14)}px ${color}55` : undefined,
+          transition: 'filter 0.7s ease, opacity 0.7s ease, box-shadow 0.7s ease',
+        }}
       >
         {data.label}
       </div>
@@ -108,9 +116,15 @@ function TopicNode({ data }: { data: CustomNodeData }) {
         style={{ opacity: 0 }}
       />
       <div
-        className={`px-2.5 py-1 rounded-md border text-xs shadow-sm max-w-[180px] transition-all ${
-          done ? 'bg-green-50 border-green-200' : 'bg-white border-gray-100'
-        }`}
+        className="px-2.5 py-1 rounded-md border text-xs max-w-[180px]"
+        style={{
+          borderColor: done ? color : '#e5e7eb',
+          backgroundColor: done ? `${color}12` : '#f8fafc',
+          filter: done ? 'grayscale(0%)' : 'grayscale(100%)',
+          opacity: done ? 1 : 0.45,
+          boxShadow: done ? `0 0 8px ${color}35` : '0 1px 2px rgba(0,0,0,0.04)',
+          transition: 'filter 0.6s ease, opacity 0.6s ease, box-shadow 0.6s ease, border-color 0.5s ease, background-color 0.5s ease',
+        }}
       >
         <div className={`flex items-center gap-1.5 ${isLeft ? 'flex-row-reverse' : ''}`}>
           <button
@@ -118,14 +132,14 @@ function TopicNode({ data }: { data: CustomNodeData }) {
             className="flex-shrink-0 transition-transform hover:scale-110"
           >
             {done ? (
-              <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />
+              <CheckCircle2 className="w-3.5 h-3.5" style={{ color }} />
             ) : (
-              <Circle className="w-3.5 h-3.5" style={{ color }} />
+              <Circle className="w-3.5 h-3.5 text-gray-300" />
             )}
           </button>
           <span
-            className={`leading-snug ${done ? 'line-through text-gray-400' : 'text-gray-700'} ${
-              isLeft ? 'text-right' : 'text-left'
+            className={`leading-snug ${isLeft ? 'text-right' : 'text-left'} ${
+              done ? 'font-medium text-gray-800' : 'text-gray-400'
             }`}
           >
             {data.label}
@@ -264,7 +278,7 @@ function buildMindMapLayout(rawNodes: MindMapNode[]): {
       id: node.id,
       type,
       position: { x: pos.x, y: pos.y },
-      data: { label: node.name, isCompleted: false, onToggle: () => {}, category, level: pos.level, side },
+      data: { label: node.name, isCompleted: false, completionRatio: 0, onToggle: () => {}, category, level: pos.level, side },
     })
   })
 
@@ -284,7 +298,8 @@ function buildMindMapLayout(rawNodes: MindMapNode[]): {
       target: node.id,
       type: 'default',
       animated: false,
-      style: { stroke: color, strokeWidth },
+      data: { categoryColor: color },
+      style: { stroke: color, strokeWidth, opacity: 0.15, transition: 'opacity 0.6s ease' },
     }
     // For root's edges, specify which handle (left or right)
     if (level === 1) {
@@ -344,21 +359,7 @@ export default function RoadmapPage() {
   const [nodes, , onNodesChange] = useNodesState(initialNodes)
   const [edges, , onEdgesChange] = useEdgesState(initialEdges)
 
-  // Overlay completion state without recomputing layout
-  const updatedNodes = useMemo(
-    () =>
-      nodes.map((node) => ({
-        ...node,
-        data: {
-          ...node.data,
-          isCompleted: completedItems.has(node.id),
-          onToggle: () => toggleComplete(node.id),
-        },
-      })),
-    [nodes, completedItems, toggleComplete]
-  )
-
-  // Sidebar data
+  // Sidebar data — must come before updatedNodes so categoryGroups is available
   const childrenMap = useMemo(() => {
     const map = new Map<string, MindMapNode[]>()
     mindMapNodes.forEach((n) => {
@@ -391,6 +392,53 @@ export default function RoadmapPage() {
       }
     })
   }, [childrenMap, rootNode])
+
+  // Overlay completion state + compute per-category completion ratio
+  const updatedNodes = useMemo(() => {
+    const categoryRatios = new Map<string, number>()
+    for (const group of categoryGroups) {
+      const done = group.topics.filter((t) => completedItems.has(t.id)).length
+      categoryRatios.set(group.categoryId, group.topics.length > 0 ? done / group.topics.length : 0)
+    }
+    return nodes.map((node) => ({
+      ...node,
+      data: {
+        ...node.data,
+        isCompleted: completedItems.has(node.id),
+        completionRatio:
+          node.data.level === 1
+            ? (categoryRatios.get(node.id) ?? 0)
+            : completedItems.has(node.id) ? 1 : 0,
+        onToggle: () => toggleComplete(node.id),
+      },
+    }))
+  }, [nodes, completedItems, toggleComplete, categoryGroups])
+
+  // Dim inactive edges; light up edges whose target has any completion
+  const updatedEdges = useMemo(() => {
+    const activated = new Set<string>()
+    for (const group of categoryGroups) {
+      for (const topic of group.topics) {
+        if (completedItems.has(topic.id)) {
+          activated.add(topic.id)
+          activated.add(group.categoryId)
+        }
+      }
+    }
+    return edges.map((edge) => {
+      const isActive = activated.has(edge.target)
+      const color = (edge.data as { categoryColor?: string })?.categoryColor ?? '#94a3b8'
+      return {
+        ...edge,
+        style: {
+          ...edge.style,
+          stroke: color,
+          opacity: isActive ? 1 : 0.15,
+          transition: 'opacity 0.6s ease',
+        },
+      }
+    })
+  }, [edges, completedItems, categoryGroups])
 
   const allCompletableIds = useMemo(
     () => new Set(categoryGroups.flatMap((g) => g.topics.map((t) => t.id))),
@@ -495,7 +543,7 @@ export default function RoadmapPage() {
       <div className="flex-1 relative">
         <ReactFlow
           nodes={updatedNodes}
-          edges={edges}
+          edges={updatedEdges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           nodeTypes={nodeTypes}
@@ -508,8 +556,9 @@ export default function RoadmapPage() {
           <Controls />
           <MiniMap
             nodeColor={(node) => {
-              if (node.data?.isCompleted) return '#10b981'
-              return categoryColors[node.data?.category ?? ''] ?? '#94a3b8'
+              if (node.data?.isCompleted) return categoryColors[node.data?.category ?? ''] ?? '#10b981'
+              if (node.data?.completionRatio > 0) return categoryColors[node.data?.category ?? ''] ?? '#94a3b8'
+              return '#d1d5db'
             }}
             maskColor="rgba(240, 240, 240, 0.6)"
           />

--- a/client/src/pages/RoadmapPage.tsx
+++ b/client/src/pages/RoadmapPage.tsx
@@ -394,9 +394,13 @@ export default function RoadmapPage() {
     })
   }, [childrenMap, rootNode])
 
-  const totalItems = mindMapNodes.length - 1
-  const completedCount = completedItems.size
-  const progress = totalItems > 0 ? Math.round((completedCount / totalItems) * 100) : 0
+  const allCompletableIds = useMemo(
+    () => new Set(categoryGroups.flatMap((g) => g.topics.map((t) => t.id))),
+    [categoryGroups]
+  )
+  const totalItems = allCompletableIds.size
+  const completedCount = [...completedItems].filter((id) => allCompletableIds.has(id)).length
+  const progress = totalItems > 0 ? Math.min(100, Math.round((completedCount / totalItems) * 100)) : 0
 
   return (
     <div className="flex w-full h-[calc(100vh-80px)]">

--- a/client/src/pages/RoadmapPage.tsx
+++ b/client/src/pages/RoadmapPage.tsx
@@ -7,7 +7,6 @@ import ReactFlow, {
   MiniMap,
   useNodesState,
   useEdgesState,
-  MarkerType,
   Panel,
   Handle,
   Position,
@@ -16,14 +15,13 @@ import 'reactflow/dist/style.css'
 import { mindMapNodes, type MindMapNode } from '@/data/mindmap-data'
 import { CheckCircle2, Circle, ChevronDown, ChevronRight } from 'lucide-react'
 
-// ─── Constants ───────────────────────────────────────────────────────────────
+// ─── Constants ────────────────────────────────────────────────────────────────
 
-const NODE_WIDTH = 200
-const NODE_HEIGHT = 60
-const H_GAP = 100
-const V_GAP = 16
+const NODE_WIDTH = 180
+const NODE_HEIGHT = 32
+const H_GAP = 90
+const V_GAP = 6
 
-// Keys in the same order as level-1 nodes appear in mindmap-data.ts
 const CATEGORY_KEYS = [
   'neural-networks',
   'perceptron',
@@ -58,70 +56,87 @@ interface CustomNodeData {
   onToggle: () => void
   category: string
   level: number
+  side: 'left' | 'right' | 'root'
 }
 
 function RootNode({ data }: { data: CustomNodeData }) {
   return (
     <>
-      <div className="px-6 py-4 rounded-2xl shadow-2xl bg-gradient-to-r from-blue-600 to-purple-600 min-w-[240px] text-center select-none">
-        <div className="text-white font-bold text-xl">{data.label}</div>
+      <Handle type="source" id="right" position={Position.Right} style={{ opacity: 0 }} />
+      <Handle type="source" id="left" position={Position.Left} style={{ opacity: 0 }} />
+      <div className="px-6 py-3 rounded-2xl shadow-2xl bg-gradient-to-r from-blue-600 to-purple-600 text-center select-none min-w-[160px]">
+        <div className="text-white font-bold text-xl leading-tight">{data.label}</div>
       </div>
-      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
     </>
   )
 }
 
 function CategoryNode({ data }: { data: CustomNodeData }) {
   const color = categoryColors[data.category] ?? '#6b7280'
+  const isLeft = data.side === 'left'
   return (
     <>
-      <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
+      <Handle
+        type="target"
+        position={isLeft ? Position.Right : Position.Left}
+        style={{ opacity: 0 }}
+      />
       <div
-        className="px-4 py-3 rounded-lg shadow-md min-w-[180px] max-w-[220px]"
-        style={{ borderLeft: `4px solid ${color}`, backgroundColor: `${color}22` }}
+        className="px-4 py-1.5 rounded-full font-bold text-sm text-white shadow-md select-none min-w-[100px] text-center"
+        style={{ backgroundColor: color }}
       >
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
-          <span className="font-bold text-sm truncate" style={{ color }}>{data.label}</span>
-        </div>
+        {data.label}
       </div>
-      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+      <Handle
+        type="source"
+        position={isLeft ? Position.Left : Position.Right}
+        style={{ opacity: 0 }}
+      />
     </>
   )
 }
 
 function TopicNode({ data }: { data: CustomNodeData }) {
   const color = categoryColors[data.category] ?? '#6b7280'
+  const isLeft = data.side === 'left'
+  const done = data.isCompleted
   return (
     <>
-      <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
+      <Handle
+        type="target"
+        position={isLeft ? Position.Right : Position.Left}
+        style={{ opacity: 0 }}
+      />
       <div
-        className={`px-3 py-2 shadow-sm rounded-lg border min-w-[140px] max-w-[200px] transition-all ${
-          data.isCompleted ? 'bg-green-50' : 'bg-white'
+        className={`px-2.5 py-1 rounded-md border text-xs shadow-sm max-w-[180px] transition-all ${
+          done ? 'bg-green-50 border-green-200' : 'bg-white border-gray-100'
         }`}
-        style={{ borderColor: data.isCompleted ? '#10b981' : `${color}66` }}
       >
-        <div className="flex items-start gap-2">
+        <div className={`flex items-center gap-1.5 ${isLeft ? 'flex-row-reverse' : ''}`}>
           <button
             onClick={data.onToggle}
-            className="mt-0.5 flex-shrink-0 transition-transform hover:scale-110"
+            className="flex-shrink-0 transition-transform hover:scale-110"
           >
-            {data.isCompleted ? (
-              <CheckCircle2 className="w-4 h-4 text-green-600" />
+            {done ? (
+              <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />
             ) : (
-              <Circle className="w-4 h-4" style={{ color }} />
+              <Circle className="w-3.5 h-3.5" style={{ color }} />
             )}
           </button>
           <span
-            className={`text-xs leading-snug ${
-              data.isCompleted ? 'line-through text-gray-400' : 'text-gray-800'
+            className={`leading-snug ${done ? 'line-through text-gray-400' : 'text-gray-700'} ${
+              isLeft ? 'text-right' : 'text-left'
             }`}
           >
             {data.label}
           </span>
         </div>
       </div>
-      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+      <Handle
+        type="source"
+        position={isLeft ? Position.Left : Position.Right}
+        style={{ opacity: 0 }}
+      />
     </>
   )
 }
@@ -134,9 +149,10 @@ const nodeTypes = {
 
 // ─── Layout Algorithm ─────────────────────────────────────────────────────────
 
-function buildTreeLayout(
-  rawNodes: MindMapNode[]
-): { nodes: Node<CustomNodeData>[]; edges: Edge[] } {
+function buildMindMapLayout(rawNodes: MindMapNode[]): {
+  nodes: Node<CustomNodeData>[]
+  edges: Edge[]
+} {
   // Deduplicate by id
   const seen = new Set<string>()
   const uniqueNodes = rawNodes.filter((n) => {
@@ -147,63 +163,94 @@ function buildTreeLayout(
 
   // Build children map
   const childrenMap = new Map<string, MindMapNode[]>()
-  uniqueNodes.forEach((node) => {
-    if (node.parentId) {
-      if (!childrenMap.has(node.parentId)) childrenMap.set(node.parentId, [])
-      childrenMap.get(node.parentId)!.push(node)
+  uniqueNodes.forEach((n) => {
+    if (n.parentId) {
+      if (!childrenMap.has(n.parentId)) childrenMap.set(n.parentId, [])
+      childrenMap.get(n.parentId)!.push(n)
     }
   })
 
   const rootNode = uniqueNodes.find((n) => n.parentId === null)
   if (!rootNode) return { nodes: [], edges: [] }
 
-  // Phase 1: Count leaves in each subtree
+  // Phase 1: Count leaves per subtree
   const leafCounts = new Map<string, number>()
-  function countLeaves(nodeId: string): number {
-    const children = childrenMap.get(nodeId) ?? []
-    if (children.length === 0) {
-      leafCounts.set(nodeId, 1)
-      return 1
-    }
-    const total = children.reduce((sum, c) => sum + countLeaves(c.id), 0)
-    leafCounts.set(nodeId, total)
+  function countLeaves(id: string): number {
+    const children = childrenMap.get(id) ?? []
+    if (children.length === 0) { leafCounts.set(id, 1); return 1 }
+    const total = children.reduce((s, c) => s + countLeaves(c.id), 0)
+    leafCounts.set(id, total)
     return total
   }
   countLeaves(rootNode.id)
 
-  // Phase 2: Assign categories top-down
+  // Phase 2: Assign categories and sides to level-1 nodes
+  // Even-indexed → right, odd-indexed → left
   const categoryOf = new Map<string, string>()
+  const sideOf = new Map<string, 'left' | 'right' | 'root'>()
   const l1Nodes = childrenMap.get(rootNode.id) ?? []
-  l1Nodes.forEach((n, i) => categoryOf.set(n.id, CATEGORY_KEYS[i] ?? 'neural-networks'))
+  l1Nodes.forEach((n, i) => {
+    categoryOf.set(n.id, CATEGORY_KEYS[i] ?? 'neural-networks')
+    sideOf.set(n.id, i % 2 === 0 ? 'right' : 'left')
+  })
+  sideOf.set(rootNode.id, 'root')
 
-  function propagateCategory(nodeId: string, inherited: string): void {
-    const cat = categoryOf.get(nodeId) ?? inherited
-    categoryOf.set(nodeId, cat)
+  // Propagate categories and sides down to all descendants
+  function propagateDown(nodeId: string, cat: string, side: 'left' | 'right'): void {
     for (const child of childrenMap.get(nodeId) ?? []) {
-      propagateCategory(child.id, cat)
+      if (!categoryOf.has(child.id)) categoryOf.set(child.id, cat)
+      if (!sideOf.has(child.id)) sideOf.set(child.id, side)
+      propagateDown(child.id, categoryOf.get(child.id)!, sideOf.get(child.id) as 'left' | 'right')
     }
   }
-  propagateCategory(rootNode.id, 'neural-networks')
+  for (const n of l1Nodes) {
+    propagateDown(n.id, categoryOf.get(n.id)!, sideOf.get(n.id) as 'left' | 'right')
+  }
 
-  // Phase 3: Assign positions (leaf-count hierarchical tree)
+  // Phase 3: Assign positions using leaf-count bands
   const positions = new Map<string, { x: number; y: number; level: number }>()
 
-  function assignPositions(nodeId: string, depth: number, yOffset: number): void {
+  function assignPositions(nodeId: string, depth: number, yOffset: number, side: 'left' | 'right'): void {
     const leaves = leafCounts.get(nodeId) ?? 1
     const bandHeight = leaves * (NODE_HEIGHT + V_GAP) - V_GAP
-    const x = depth * (NODE_WIDTH + H_GAP)
+    const xSign = side === 'right' ? 1 : -1
+    const x = xSign * depth * (NODE_WIDTH + H_GAP)
     const y = yOffset + bandHeight / 2 - NODE_HEIGHT / 2
     positions.set(nodeId, { x, y, level: depth })
 
     let currentY = yOffset
     for (const child of childrenMap.get(nodeId) ?? []) {
-      const childLeaves = leafCounts.get(child.id) ?? 1
-      const childBand = childLeaves * (NODE_HEIGHT + V_GAP)
-      assignPositions(child.id, depth + 1, currentY)
+      const childBand = (leafCounts.get(child.id) ?? 1) * (NODE_HEIGHT + V_GAP)
+      assignPositions(child.id, depth + 1, currentY, side)
       currentY += childBand
     }
   }
-  assignPositions(rootNode.id, 0, 0)
+
+  // Root at origin
+  positions.set(rootNode.id, { x: 0, y: 0, level: 0 })
+
+  // Separate l1 by side, center each side vertically around y=0
+  const rightL1 = l1Nodes.filter((_, i) => i % 2 === 0)
+  const leftL1 = l1Nodes.filter((_, i) => i % 2 === 1)
+
+  const rightLeaves = rightL1.reduce((s, n) => s + (leafCounts.get(n.id) ?? 1), 0)
+  const leftLeaves = leftL1.reduce((s, n) => s + (leafCounts.get(n.id) ?? 1), 0)
+  const rightTotalH = rightLeaves * (NODE_HEIGHT + V_GAP) - V_GAP
+  const leftTotalH = leftLeaves * (NODE_HEIGHT + V_GAP) - V_GAP
+
+  let rightY = -rightTotalH / 2
+  for (const n of rightL1) {
+    const band = (leafCounts.get(n.id) ?? 1) * (NODE_HEIGHT + V_GAP)
+    assignPositions(n.id, 1, rightY, 'right')
+    rightY += band
+  }
+
+  let leftY = -leftTotalH / 2
+  for (const n of leftL1) {
+    const band = (leafCounts.get(n.id) ?? 1) * (NODE_HEIGHT + V_GAP)
+    assignPositions(n.id, 1, leftY, 'left')
+    leftY += band
+  }
 
   // Build ReactFlow nodes
   const nodes: Node<CustomNodeData>[] = []
@@ -211,37 +258,39 @@ function buildTreeLayout(
     const pos = positions.get(node.id)
     if (!pos) return
     const category = categoryOf.get(node.id) ?? 'neural-networks'
+    const side = sideOf.get(node.id) ?? 'right'
     const type = pos.level === 0 ? 'root' : pos.level === 1 ? 'category' : 'topic'
     nodes.push({
       id: node.id,
       type,
       position: { x: pos.x, y: pos.y },
-      data: {
-        label: node.name,
-        isCompleted: false,
-        onToggle: () => {},
-        category,
-        level: pos.level,
-      },
+      data: { label: node.name, isCompleted: false, onToggle: () => {}, category, level: pos.level, side },
     })
   })
 
-  // Build edges with category colors
+  // Build edges (bezier curves, no arrows, category-colored)
   const edges: Edge[] = []
   uniqueNodes.forEach((node) => {
     if (!node.parentId) return
     if (!positions.has(node.id) || !positions.has(node.parentId)) return
     const level = positions.get(node.id)!.level
+    const side = sideOf.get(node.id) ?? 'right'
     const color = categoryColors[categoryOf.get(node.id) ?? ''] ?? '#94a3b8'
-    edges.push({
+    const strokeWidth = level === 1 ? 4 : level === 2 ? 2.5 : 1.5
+
+    const edge: Edge = {
       id: `${node.parentId}-${node.id}`,
       source: node.parentId,
       target: node.id,
-      type: 'smoothstep',
+      type: 'default',
       animated: false,
-      style: { stroke: color, strokeWidth: level === 1 ? 2.5 : 1.5 },
-      markerEnd: { type: MarkerType.ArrowClosed, color },
-    })
+      style: { stroke: color, strokeWidth },
+    }
+    // For root's edges, specify which handle (left or right)
+    if (level === 1) {
+      edge.sourceHandle = side === 'left' ? 'left' : 'right'
+    }
+    edges.push(edge)
   })
 
   return { nodes, edges }
@@ -269,7 +318,7 @@ export default function RoadmapPage() {
     } catch { /* ignore */ }
   }, [])
 
-  // Save to localStorage on change
+  // Persist to localStorage on change
   useEffect(() => {
     localStorage.setItem('dl-roadmap-completed', JSON.stringify([...completedItems]))
   }, [completedItems])
@@ -290,14 +339,14 @@ export default function RoadmapPage() {
     })
   }, [])
 
-  // Build layout once — mindMapNodes is a stable module constant
+  // Layout computed once — mindMapNodes is a stable module constant
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const { nodes: initialNodes, edges: initialEdges } = useMemo(() => buildTreeLayout(mindMapNodes), [])
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(() => buildMindMapLayout(mindMapNodes), [])
 
   const [nodes, , onNodesChange] = useNodesState(initialNodes)
   const [edges, , onEdgesChange] = useEdgesState(initialEdges)
 
-  // Overlay completion state on top of stable positions
+  // Overlay completion state without recomputing layout
   const updatedNodes = useMemo(
     () =>
       nodes.map((node) => ({
@@ -311,7 +360,7 @@ export default function RoadmapPage() {
     [nodes, completedItems, toggleComplete]
   )
 
-  // Build sidebar category groups
+  // Sidebar data
   const childrenMap = useMemo(() => {
     const map = new Map<string, MindMapNode[]>()
     mindMapNodes.forEach((n) => {
@@ -345,7 +394,7 @@ export default function RoadmapPage() {
     })
   }, [childrenMap, rootNode])
 
-  const totalItems = mindMapNodes.length - 1 // exclude root
+  const totalItems = mindMapNodes.length - 1
   const completedCount = completedItems.size
   const progress = totalItems > 0 ? Math.round((completedCount / totalItems) * 100) : 0
 
@@ -354,7 +403,6 @@ export default function RoadmapPage() {
       {/* Sidebar */}
       {showSidebar && (
         <div className="w-72 bg-white border-r border-gray-200 overflow-hidden flex-shrink-0 flex flex-col">
-          {/* Sidebar header */}
           <div className="p-4 border-b border-gray-100 flex-shrink-0">
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-base font-bold text-gray-900">Topics</h2>
@@ -365,9 +413,7 @@ export default function RoadmapPage() {
                 ✕
               </button>
             </div>
-            <div className="text-xs text-gray-500 mb-1.5">
-              {completedCount} / {totalItems} completed
-            </div>
+            <div className="text-xs text-gray-500 mb-1.5">{completedCount} / {totalItems} completed</div>
             <div className="w-full bg-gray-100 rounded-full h-1.5">
               <div
                 className="h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-purple-500 transition-all"
@@ -376,36 +422,29 @@ export default function RoadmapPage() {
             </div>
           </div>
 
-          {/* Category sections */}
           <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
             {categoryGroups.map((group) => {
               const isCollapsed = collapsedCategories.has(group.categoryId)
               const groupCompleted = group.topics.filter((t) => completedItems.has(t.id)).length
               return (
                 <div key={group.categoryId}>
-                  {/* Category header */}
                   <button
                     onClick={() => toggleCategory(group.categoryId)}
                     className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-gray-50 transition-colors"
                   >
-                    <div
-                      className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: group.color }}
-                    />
+                    <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: group.color }} />
                     <span className="font-semibold text-sm text-gray-800 flex-1 text-left truncate">
                       {group.categoryName}
                     </span>
                     <span className="text-xs text-gray-400 flex-shrink-0">
                       {groupCompleted}/{group.topics.length}
                     </span>
-                    {isCollapsed ? (
-                      <ChevronRight className="w-3 h-3 text-gray-400 flex-shrink-0" />
-                    ) : (
-                      <ChevronDown className="w-3 h-3 text-gray-400 flex-shrink-0" />
-                    )}
+                    {isCollapsed
+                      ? <ChevronRight className="w-3 h-3 text-gray-400 flex-shrink-0" />
+                      : <ChevronDown className="w-3 h-3 text-gray-400 flex-shrink-0" />
+                    }
                   </button>
 
-                  {/* Per-category progress bar */}
                   {!isCollapsed && group.topics.length > 0 && (
                     <div className="ml-5 mr-3 mb-1">
                       <div className="w-full bg-gray-100 rounded-full h-1">
@@ -420,7 +459,6 @@ export default function RoadmapPage() {
                     </div>
                   )}
 
-                  {/* Topic list */}
                   {!isCollapsed && (
                     <div className="ml-4 mb-1 space-y-0.5">
                       {group.topics.map((topic) => {
@@ -430,18 +468,13 @@ export default function RoadmapPage() {
                             key={topic.id}
                             onClick={() => toggleComplete(topic.id)}
                             className={`w-full text-left px-3 py-1.5 rounded-md text-xs transition-colors flex items-center gap-2 ${
-                              done
-                                ? 'text-gray-400'
-                                : 'text-gray-700 hover:bg-gray-50'
+                              done ? 'text-gray-400' : 'text-gray-700 hover:bg-gray-50'
                             }`}
                           >
                             {done ? (
                               <CheckCircle2 className="w-3 h-3 text-green-500 flex-shrink-0" />
                             ) : (
-                              <Circle
-                                className="w-3 h-3 flex-shrink-0"
-                                style={{ color: group.color }}
-                              />
+                              <Circle className="w-3 h-3 flex-shrink-0" style={{ color: group.color }} />
                             )}
                             <span className={done ? 'line-through' : ''}>{topic.name}</span>
                           </button>
@@ -456,43 +489,41 @@ export default function RoadmapPage() {
         </div>
       )}
 
-      {/* Main canvas */}
+      {/* Canvas */}
       <div className="flex-1 relative">
-        <div className="w-full h-full">
-          <ReactFlow
-            nodes={updatedNodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            nodeTypes={nodeTypes}
-            fitView
-            fitViewOptions={{ padding: 0.15 }}
-            minZoom={0.03}
-            maxZoom={1.5}
-          >
-            <Background color="#e2e8f0" gap={24} />
-            <Controls />
-            <MiniMap
-              nodeColor={(node) => {
-                if (node.data?.isCompleted) return '#10b981'
-                return categoryColors[node.data?.category ?? ''] ?? '#94a3b8'
-              }}
-              maskColor="rgba(240, 240, 240, 0.6)"
-            />
-            {!showSidebar && (
-              <Panel position="top-left" className="bg-white rounded-lg shadow-lg px-4 py-3 m-4 flex items-center gap-3">
-                <button
-                  onClick={() => setShowSidebar(true)}
-                  className="text-sm font-medium text-blue-600 hover:underline"
-                >
-                  Show Topics
-                </button>
-                <span className="text-gray-300">|</span>
-                <span className="text-sm text-gray-600">{progress}% complete</span>
-              </Panel>
-            )}
-          </ReactFlow>
-        </div>
+        <ReactFlow
+          nodes={updatedNodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.12 }}
+          minZoom={0.03}
+          maxZoom={1.5}
+        >
+          <Background color="#e2e8f0" gap={28} />
+          <Controls />
+          <MiniMap
+            nodeColor={(node) => {
+              if (node.data?.isCompleted) return '#10b981'
+              return categoryColors[node.data?.category ?? ''] ?? '#94a3b8'
+            }}
+            maskColor="rgba(240, 240, 240, 0.6)"
+          />
+          {!showSidebar && (
+            <Panel position="top-left" className="bg-white rounded-lg shadow-lg px-4 py-3 m-4 flex items-center gap-3">
+              <button
+                onClick={() => setShowSidebar(true)}
+                className="text-sm font-medium text-blue-600 hover:underline"
+              >
+                Show Topics
+              </button>
+              <span className="text-gray-300">|</span>
+              <span className="text-sm text-gray-600">{progress}% complete</span>
+            </Panel>
+          )}
+        </ReactFlow>
       </div>
     </div>
   )

--- a/client/src/pages/RoadmapPage.tsx
+++ b/client/src/pages/RoadmapPage.tsx
@@ -14,37 +14,92 @@ import ReactFlow, {
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import { mindMapNodes, type MindMapNode } from '@/data/mindmap-data'
-import { CheckCircle2, Circle } from 'lucide-react'
+import { CheckCircle2, Circle, ChevronDown, ChevronRight } from 'lucide-react'
 
-// Colors for different categories
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const NODE_WIDTH = 200
+const NODE_HEIGHT = 60
+const H_GAP = 100
+const V_GAP = 16
+
+// Keys in the same order as level-1 nodes appear in mindmap-data.ts
+const CATEGORY_KEYS = [
+  'neural-networks',
+  'perceptron',
+  'optimization',
+  'regularization',
+  'transformers',
+  'vision-language',
+  'self-supervised',
+  'graph-networks',
+  'training',
+  'advanced',
+]
+
 const categoryColors: Record<string, string> = {
-  'fundamentals': '#3b82f6', // blue
-  'neural-networks': '#8b5cf6', // purple
-  'deep-learning-architectures': '#ec4899', // pink
-  'training-optimization': '#f59e0b', // amber
-  'applications': '#10b981', // green
+  'neural-networks':  '#8b5cf6',
+  'perceptron':       '#3b82f6',
+  'optimization':     '#f59e0b',
+  'regularization':   '#ef4444',
+  'transformers':     '#ec4899',
+  'vision-language':  '#06b6d4',
+  'self-supervised':  '#10b981',
+  'graph-networks':   '#84cc16',
+  'training':         '#f97316',
+  'advanced':         '#a855f7',
 }
+
+// ─── Node Components ──────────────────────────────────────────────────────────
 
 interface CustomNodeData {
   label: string
-  description?: string
   isCompleted: boolean
   onToggle: () => void
   category: string
   level: number
 }
 
-function CustomNode({ data }: { data: CustomNodeData }) {
-  const color = categoryColors[data.category] || '#6b7280'
-  
+function RootNode({ data }: { data: CustomNodeData }) {
   return (
     <>
-      <Handle type="target" position={Position.Left} />
+      <div className="px-6 py-4 rounded-2xl shadow-2xl bg-gradient-to-r from-blue-600 to-purple-600 min-w-[240px] text-center select-none">
+        <div className="text-white font-bold text-xl">{data.label}</div>
+      </div>
+      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+    </>
+  )
+}
+
+function CategoryNode({ data }: { data: CustomNodeData }) {
+  const color = categoryColors[data.category] ?? '#6b7280'
+  return (
+    <>
+      <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
       <div
-        className={`px-3 py-2 shadow-md rounded-lg border-2 min-w-[140px] max-w-[200px] transition-all ${
-          data.isCompleted ? 'bg-green-50 border-green-500' : 'bg-white border-gray-300'
+        className="px-4 py-3 rounded-lg shadow-md min-w-[180px] max-w-[220px]"
+        style={{ borderLeft: `4px solid ${color}`, backgroundColor: `${color}22` }}
+      >
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+          <span className="font-bold text-sm truncate" style={{ color }}>{data.label}</span>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+    </>
+  )
+}
+
+function TopicNode({ data }: { data: CustomNodeData }) {
+  const color = categoryColors[data.category] ?? '#6b7280'
+  return (
+    <>
+      <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
+      <div
+        className={`px-3 py-2 shadow-sm rounded-lg border min-w-[140px] max-w-[200px] transition-all ${
+          data.isCompleted ? 'bg-green-50' : 'bg-white'
         }`}
-        style={{ borderColor: data.isCompleted ? '#10b981' : color }}
+        style={{ borderColor: data.isCompleted ? '#10b981' : `${color}66` }}
       >
         <div className="flex items-start gap-2">
           <button
@@ -54,72 +109,195 @@ function CustomNode({ data }: { data: CustomNodeData }) {
             {data.isCompleted ? (
               <CheckCircle2 className="w-4 h-4 text-green-600" />
             ) : (
-              <Circle className="w-4 h-4 text-gray-400" />
+              <Circle className="w-4 h-4" style={{ color }} />
             )}
           </button>
-          <div className="flex-1 min-w-0">
-            <div
-              className={`font-semibold text-sm leading-snug ${
-                data.isCompleted ? 'line-through text-gray-500' : 'text-gray-900'
-              }`}
-            >
-              {data.label}
-            </div>
-            {data.description && (
-              <div className="text-xs text-gray-600 mt-1 line-clamp-2">
-                {data.description}
-              </div>
-            )}
-          </div>
+          <span
+            className={`text-xs leading-snug ${
+              data.isCompleted ? 'line-through text-gray-400' : 'text-gray-800'
+            }`}
+          >
+            {data.label}
+          </span>
         </div>
       </div>
-      <Handle type="source" position={Position.Right} />
+      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
     </>
   )
 }
 
 const nodeTypes = {
-  custom: CustomNode,
+  root: RootNode,
+  category: CategoryNode,
+  topic: TopicNode,
+}
+
+// ─── Layout Algorithm ─────────────────────────────────────────────────────────
+
+function buildTreeLayout(
+  rawNodes: MindMapNode[]
+): { nodes: Node<CustomNodeData>[]; edges: Edge[] } {
+  // Deduplicate by id
+  const seen = new Set<string>()
+  const uniqueNodes = rawNodes.filter((n) => {
+    if (seen.has(n.id)) return false
+    seen.add(n.id)
+    return true
+  })
+
+  // Build children map
+  const childrenMap = new Map<string, MindMapNode[]>()
+  uniqueNodes.forEach((node) => {
+    if (node.parentId) {
+      if (!childrenMap.has(node.parentId)) childrenMap.set(node.parentId, [])
+      childrenMap.get(node.parentId)!.push(node)
+    }
+  })
+
+  const rootNode = uniqueNodes.find((n) => n.parentId === null)
+  if (!rootNode) return { nodes: [], edges: [] }
+
+  // Phase 1: Count leaves in each subtree
+  const leafCounts = new Map<string, number>()
+  function countLeaves(nodeId: string): number {
+    const children = childrenMap.get(nodeId) ?? []
+    if (children.length === 0) {
+      leafCounts.set(nodeId, 1)
+      return 1
+    }
+    const total = children.reduce((sum, c) => sum + countLeaves(c.id), 0)
+    leafCounts.set(nodeId, total)
+    return total
+  }
+  countLeaves(rootNode.id)
+
+  // Phase 2: Assign categories top-down
+  const categoryOf = new Map<string, string>()
+  const l1Nodes = childrenMap.get(rootNode.id) ?? []
+  l1Nodes.forEach((n, i) => categoryOf.set(n.id, CATEGORY_KEYS[i] ?? 'neural-networks'))
+
+  function propagateCategory(nodeId: string, inherited: string): void {
+    const cat = categoryOf.get(nodeId) ?? inherited
+    categoryOf.set(nodeId, cat)
+    for (const child of childrenMap.get(nodeId) ?? []) {
+      propagateCategory(child.id, cat)
+    }
+  }
+  propagateCategory(rootNode.id, 'neural-networks')
+
+  // Phase 3: Assign positions (leaf-count hierarchical tree)
+  const positions = new Map<string, { x: number; y: number; level: number }>()
+
+  function assignPositions(nodeId: string, depth: number, yOffset: number): void {
+    const leaves = leafCounts.get(nodeId) ?? 1
+    const bandHeight = leaves * (NODE_HEIGHT + V_GAP) - V_GAP
+    const x = depth * (NODE_WIDTH + H_GAP)
+    const y = yOffset + bandHeight / 2 - NODE_HEIGHT / 2
+    positions.set(nodeId, { x, y, level: depth })
+
+    let currentY = yOffset
+    for (const child of childrenMap.get(nodeId) ?? []) {
+      const childLeaves = leafCounts.get(child.id) ?? 1
+      const childBand = childLeaves * (NODE_HEIGHT + V_GAP)
+      assignPositions(child.id, depth + 1, currentY)
+      currentY += childBand
+    }
+  }
+  assignPositions(rootNode.id, 0, 0)
+
+  // Build ReactFlow nodes
+  const nodes: Node<CustomNodeData>[] = []
+  uniqueNodes.forEach((node) => {
+    const pos = positions.get(node.id)
+    if (!pos) return
+    const category = categoryOf.get(node.id) ?? 'neural-networks'
+    const type = pos.level === 0 ? 'root' : pos.level === 1 ? 'category' : 'topic'
+    nodes.push({
+      id: node.id,
+      type,
+      position: { x: pos.x, y: pos.y },
+      data: {
+        label: node.name,
+        isCompleted: false,
+        onToggle: () => {},
+        category,
+        level: pos.level,
+      },
+    })
+  })
+
+  // Build edges with category colors
+  const edges: Edge[] = []
+  uniqueNodes.forEach((node) => {
+    if (!node.parentId) return
+    if (!positions.has(node.id) || !positions.has(node.parentId)) return
+    const level = positions.get(node.id)!.level
+    const color = categoryColors[categoryOf.get(node.id) ?? ''] ?? '#94a3b8'
+    edges.push({
+      id: `${node.parentId}-${node.id}`,
+      source: node.parentId,
+      target: node.id,
+      type: 'smoothstep',
+      animated: false,
+      style: { stroke: color, strokeWidth: level === 1 ? 2.5 : 1.5 },
+      markerEnd: { type: MarkerType.ArrowClosed, color },
+    })
+  })
+
+  return { nodes, edges }
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+interface CategoryGroup {
+  categoryId: string
+  categoryName: string
+  color: string
+  topics: MindMapNode[]
 }
 
 export default function RoadmapPage() {
   const [completedItems, setCompletedItems] = useState<Set<string>>(new Set())
   const [showSidebar, setShowSidebar] = useState(true)
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('dl-roadmap-completed')
+      if (saved) setCompletedItems(new Set(JSON.parse(saved) as string[]))
+    } catch { /* ignore */ }
+  }, [])
+
+  // Save to localStorage on change
+  useEffect(() => {
+    localStorage.setItem('dl-roadmap-completed', JSON.stringify([...completedItems]))
+  }, [completedItems])
 
   const toggleComplete = useCallback((id: string) => {
     setCompletedItems((prev) => {
-      const newSet = new Set(prev)
-      if (newSet.has(id)) {
-        newSet.delete(id)
-      } else {
-        newSet.add(id)
-      }
-      return newSet
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
     })
   }, [])
 
-  // Convert mind map data to nodes and edges with tree layout
-  const { nodes: initialNodes, edges: initialEdges } = useMemo(
-    () => buildTreeLayout(mindMapNodes, completedItems, toggleComplete),
-    [completedItems, toggleComplete]
-  )
+  const toggleCategory = useCallback((catId: string) => {
+    setCollapsedCategories((prev) => {
+      const next = new Set(prev)
+      next.has(catId) ? next.delete(catId) : next.add(catId)
+      return next
+    })
+  }, [])
 
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
-  
-  // Update edges when they change
-  useEffect(() => {
-    console.log('Setting edges:', initialEdges.length, 'edges')
-    setEdges(initialEdges)
-  }, [initialEdges, setEdges])
-  
-  // Debug: log edges on mount
-  useEffect(() => {
-    console.log('Edges in state:', edges.length)
-    console.log('Sample edges:', edges.slice(0, 3))
-  }, [edges])
+  // Build layout once — mindMapNodes is a stable module constant
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(() => buildTreeLayout(mindMapNodes), [])
 
-  // Update nodes when completion status changes
+  const [nodes, , onNodesChange] = useNodesState(initialNodes)
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges)
+
+  // Overlay completion state on top of stable positions
   const updatedNodes = useMemo(
     () =>
       nodes.map((node) => ({
@@ -133,272 +311,189 @@ export default function RoadmapPage() {
     [nodes, completedItems, toggleComplete]
   )
 
-  const totalItems = mindMapNodes.length
+  // Build sidebar category groups
+  const childrenMap = useMemo(() => {
+    const map = new Map<string, MindMapNode[]>()
+    mindMapNodes.forEach((n) => {
+      if (n.parentId) {
+        if (!map.has(n.parentId)) map.set(n.parentId, [])
+        map.get(n.parentId)!.push(n)
+      }
+    })
+    return map
+  }, [])
+
+  const rootNode = useMemo(() => mindMapNodes.find((n) => n.parentId === null)!, [])
+
+  const categoryGroups = useMemo((): CategoryGroup[] => {
+    const l1Nodes = childrenMap.get(rootNode.id) ?? []
+    return l1Nodes.map((l1, i) => {
+      const descendants: MindMapNode[] = []
+      function collect(id: string) {
+        for (const child of childrenMap.get(id) ?? []) {
+          descendants.push(child)
+          collect(child.id)
+        }
+      }
+      collect(l1.id)
+      return {
+        categoryId: l1.id,
+        categoryName: l1.name,
+        color: categoryColors[CATEGORY_KEYS[i] ?? 'neural-networks'] ?? '#6b7280',
+        topics: descendants,
+      }
+    })
+  }, [childrenMap, rootNode])
+
+  const totalItems = mindMapNodes.length - 1 // exclude root
   const completedCount = completedItems.size
-  const progress = Math.round((completedCount / totalItems) * 100)
-// Group nodes by parent for sidebar
-  const groupedNodes = mindMapNodes.reduce((acc, node) => {
-    const parentId = node.parentId || 'root'
-    if (!acc[parentId]) acc[parentId] = []
-    acc[parentId].push(node)
-    return acc
-  }, {} as Record<string, MindMapNode[]>)
+  const progress = totalItems > 0 ? Math.round((completedCount / totalItems) * 100) : 0
 
   return (
     <div className="flex w-full h-[calc(100vh-80px)]">
       {/* Sidebar */}
       {showSidebar && (
-        <div className="w-80 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
-          <div className="p-4">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-bold text-gray-900">All Topics</h2>
+        <div className="w-72 bg-white border-r border-gray-200 overflow-hidden flex-shrink-0 flex flex-col">
+          {/* Sidebar header */}
+          <div className="p-4 border-b border-gray-100 flex-shrink-0">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-base font-bold text-gray-900">Topics</h2>
               <button
                 onClick={() => setShowSidebar(false)}
-                className="p-1 hover:bg-gray-100 rounded"
+                className="p-1 hover:bg-gray-100 rounded text-gray-400 text-sm leading-none"
               >
                 ✕
               </button>
             </div>
-            <div className="space-y-2">
-              {mindMapNodes.map((node) => (
-                <button
-                  key={node.id}
-                  onClick={() => toggleComplete(node.id)}
-                  className={`w-full text-left px-3 py-2 rounded-lg border transition-all ${
-                    completedItems.has(node.id)
-                      ? 'bg-green-50 border-green-300'
-                      : 'bg-gray-50 border-gray-200 hover:border-gray-300'
-                  }`}
-                >
-                  <div className="flex items-start gap-2">
-                    {completedItems.has(node.id) ? (
-                      <CheckCircle2 className="w-4 h-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    ) : (
-                      <Circle className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
-                    )}
-                    <span
-                      className={`text-sm ${
-                        completedItems.has(node.id)
-                          ? 'line-through text-gray-500'
-                          : 'text-gray-900'
-                      }`}
-                    >
-                      {node.name}
-                    </span>
-                  </div>
-                </button>
-              ))}
+            <div className="text-xs text-gray-500 mb-1.5">
+              {completedCount} / {totalItems} completed
             </div>
+            <div className="w-full bg-gray-100 rounded-full h-1.5">
+              <div
+                className="h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-purple-500 transition-all"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Category sections */}
+          <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
+            {categoryGroups.map((group) => {
+              const isCollapsed = collapsedCategories.has(group.categoryId)
+              const groupCompleted = group.topics.filter((t) => completedItems.has(t.id)).length
+              return (
+                <div key={group.categoryId}>
+                  {/* Category header */}
+                  <button
+                    onClick={() => toggleCategory(group.categoryId)}
+                    className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-gray-50 transition-colors"
+                  >
+                    <div
+                      className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: group.color }}
+                    />
+                    <span className="font-semibold text-sm text-gray-800 flex-1 text-left truncate">
+                      {group.categoryName}
+                    </span>
+                    <span className="text-xs text-gray-400 flex-shrink-0">
+                      {groupCompleted}/{group.topics.length}
+                    </span>
+                    {isCollapsed ? (
+                      <ChevronRight className="w-3 h-3 text-gray-400 flex-shrink-0" />
+                    ) : (
+                      <ChevronDown className="w-3 h-3 text-gray-400 flex-shrink-0" />
+                    )}
+                  </button>
+
+                  {/* Per-category progress bar */}
+                  {!isCollapsed && group.topics.length > 0 && (
+                    <div className="ml-5 mr-3 mb-1">
+                      <div className="w-full bg-gray-100 rounded-full h-1">
+                        <div
+                          className="h-1 rounded-full transition-all"
+                          style={{
+                            width: `${(groupCompleted / group.topics.length) * 100}%`,
+                            backgroundColor: group.color,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Topic list */}
+                  {!isCollapsed && (
+                    <div className="ml-4 mb-1 space-y-0.5">
+                      {group.topics.map((topic) => {
+                        const done = completedItems.has(topic.id)
+                        return (
+                          <button
+                            key={topic.id}
+                            onClick={() => toggleComplete(topic.id)}
+                            className={`w-full text-left px-3 py-1.5 rounded-md text-xs transition-colors flex items-center gap-2 ${
+                              done
+                                ? 'text-gray-400'
+                                : 'text-gray-700 hover:bg-gray-50'
+                            }`}
+                          >
+                            {done ? (
+                              <CheckCircle2 className="w-3 h-3 text-green-500 flex-shrink-0" />
+                            ) : (
+                              <Circle
+                                className="w-3 h-3 flex-shrink-0"
+                                style={{ color: group.color }}
+                              />
+                            )}
+                            <span className={done ? 'line-through' : ''}>{topic.name}</span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       )}
 
-      {/* Main content */}
+      {/* Main canvas */}
       <div className="flex-1 relative">
-        {!showSidebar && (
-          <button
-            onClick={() => setShowSidebar(true)}
-            className="absolute top-4 left-4 z-10 bg-white px-3 py-2 rounded-lg shadow-lg border border-gray-200 hover:bg-gray-50"
+        <div className="w-full h-full">
+          <ReactFlow
+            nodes={updatedNodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.15 }}
+            minZoom={0.03}
+            maxZoom={1.5}
           >
-            Show Topics List
-          </button>
-        )}
-      <div className="w-full h-[calc(100vh-80px)]">
-      <ReactFlow
-        nodes={updatedNodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        nodeTypes={nodeTypes}
-        fitView
-        minZoom={0.05}
-        maxZoom={1.2}
-        defaultViewport={{ x: 0, y: 0, zoom: 0.5 }}
-      >
-        <Background />
-        <Controls />
-        <MiniMap
-          nodeColor={(node) => (node.data.isCompleted ? '#10b981' : '#3b82f6')}
-          maskColor="rgb(240, 240, 240, 0.6)"
-        />
-        <Panel position="top-left" className="bg-white rounded-lg shadow-lg p-4 m-4">
-          <h3 className="font-bold text-lg mb-2">Deep Learning Roadmap</h3>
-          <div className="w-56">
-            <div className="flex justify-between text-sm mb-1">
-              <span>{completedCount} / {totalItems} concepts</span>
-              <span className="font-bold">{progress}%</span>
-            </div>
-            <div className="w-full bg-gray-200 rounded-full h-3">
-              <div
-                className="bg-gradient-to-r from-blue-500 to-green-500 h-3 rounded-full transition-all"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-            <p className="text-xs text-gray-600 mt-3">
-              Click any node to mark it as completed
-            </p>
-          </div>
-        </Panel>
-      </ReactFlow>
-      </div>
+            <Background color="#e2e8f0" gap={24} />
+            <Controls />
+            <MiniMap
+              nodeColor={(node) => {
+                if (node.data?.isCompleted) return '#10b981'
+                return categoryColors[node.data?.category ?? ''] ?? '#94a3b8'
+              }}
+              maskColor="rgba(240, 240, 240, 0.6)"
+            />
+            {!showSidebar && (
+              <Panel position="top-left" className="bg-white rounded-lg shadow-lg px-4 py-3 m-4 flex items-center gap-3">
+                <button
+                  onClick={() => setShowSidebar(true)}
+                  className="text-sm font-medium text-blue-600 hover:underline"
+                >
+                  Show Topics
+                </button>
+                <span className="text-gray-300">|</span>
+                <span className="text-sm text-gray-600">{progress}% complete</span>
+              </Panel>
+            )}
+          </ReactFlow>
+        </div>
       </div>
     </div>
   )
-}
-
-function buildTreeLayout(
-  mindMapNodes: MindMapNode[],
-  completedItems: Set<string>,
-  toggleComplete: (id: string) => void
-): { nodes: Node<CustomNodeData>[]; edges: Edge[] } {
-  const nodes: Node<CustomNodeData>[] = []
-  const edges: Edge[] = []
-
-  // Build parent-child map
-  const childrenMap = new Map<string, MindMapNode[]>()
-  mindMapNodes.forEach((node) => {
-    if (node.parentId) {
-      if (!childrenMap.has(node.parentId)) {
-        childrenMap.set(node.parentId, [])
-      }
-      childrenMap.get(node.parentId)!.push(node)
-    }
-  })
-
-  // Find root node
-  const rootNode = mindMapNodes.find((n) => n.parentId === null)
-  if (!rootNode) return { nodes: [], edges: [] }
-
-  // Calculate node positions using radial mind map layout
-  const nodePositions = new Map<string, { x: number; y: number; level: number }>()
-  
-  // Categories for color coding
-  const categories = [
-    'neural-networks',
-    'fundamentals', 
-    'architectures',
-    'optimization',
-    'applications'
-  ]
-
-  function calculateRadialPositions(
-    nodeId: string,
-    angle: number,
-    radius: number,
-    level: number,
-    angleSpan: number
-  ): void {
-    const x = radius * Math.cos(angle)
-    const y = radius * Math.sin(angle)
-    
-    nodePositions.set(nodeId, { x, y, level })
-
-    const children = childrenMap.get(nodeId) || []
-    if (children.length === 0) return
-
-    // Extremely large radius increment to prevent overlap
-    const radiusIncrement = 600 + (level * 150)
-    const newRadius = radius + radiusIncrement
-    
-    // Calculate minimum angle needed based on node dimensions with large safety margin
-    const nodeWidth = 150
-    const nodeHeight = 50
-    const effectiveSize = Math.sqrt(nodeWidth * nodeWidth + nodeHeight * nodeHeight)
-    const minAngle = (effectiveSize / newRadius) * 3.0 // Triple spacing
-    const totalAngleNeeded = minAngle * children.length
-    
-    // Always use at least the minimum needed angle
-    const effectiveSpan = Math.max(angleSpan, totalAngleNeeded)
-    const anglePerChild = effectiveSpan / children.length
-    const startAngle = angle - effectiveSpan / 2
-
-    children.forEach((child, idx) => {
-      const childAngle = startAngle + anglePerChild * (idx + 0.5)
-      const childAngleSpan = anglePerChild * 0.75
-      calculateRadialPositions(child.id, childAngle, newRadius, level + 1, childAngleSpan)
-    })
-  }
-
-  // Position root at center
-  nodePositions.set(rootNode.id, { x: 0, y: 0, level: 0 })
-
-  // Get first-level children and distribute them radially
-  const rootChildren = childrenMap.get(rootNode.id) || []
-  const angleStep = (2 * Math.PI) / rootChildren.length
-
-  rootChildren.forEach((child, idx) => {
-    const angle = idx * angleStep - Math.PI / 2 // Start from top
-    const angleSpan = angleStep * 0.8
-    calculateRadialPositions(child.id, angle, 600, 1, angleSpan)
-  })
-
-  console.log('Total nodes in data:', mindMapNodes.length)
-  console.log('Nodes with positions:', nodePositions.size)
-
-  // Create React Flow nodes
-  mindMapNodes.forEach((node) => {
-    const pos = nodePositions.get(node.id)
-    if (!pos) {
-      console.log('Node without position:', node.name, node.id, 'parentId:', node.parentId)
-      return
-    }
-
-    // Determine category based on position in tree
-    let category = 'fundamentals'
-    if (pos.level === 1) {
-      const rootChildren = childrenMap.get(rootNode.id) || []
-      const categoryIndex = rootChildren.findIndex(c => c.id === node.id)
-      if (categoryIndex >= 0) {
-        category = categories[categoryIndex % categories.length]
-      }
-    } else {
-      // Inherit category from parent's branch
-      let current = node
-      while (current.parentId && current.parentId !== rootNode.id) {
-        const parent = mindMapNodes.find(n => n.id === current.parentId)
-        if (!parent) break
-        current = parent
-      }
-      const rootChildren = childrenMap.get(rootNode.id) || []
-      const categoryIndex = rootChildren.findIndex(c => c.id === current.id)
-      if (categoryIndex >= 0) {
-        category = categories[categoryIndex % categories.length]
-      }
-    }
-
-    nodes.push({
-      id: node.id,
-      type: 'custom',
-      position: { x: pos.x, y: pos.y },
-      data: {
-        label: node.name,
-        isCompleted: completedItems.has(node.id),
-        onToggle: () => toggleComplete(node.id),
-        category: category,
-        level: pos.level,
-      },
-    })
-  })
-
-  // Create edges - only for nodes that have positions
-  mindMapNodes.forEach((node) => {
-    if (node.parentId && nodePositions.has(node.id) && nodePositions.has(node.parentId)) {
-      edges.push({
-        id: `${node.parentId}-${node.id}`,
-        source: node.parentId,
-        target: node.id,
-        type: 'smoothstep',
-        animated: false,
-        style: { stroke: '#475569', strokeWidth: 2 },
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          color: '#475569',
-        },
-      })
-    }
-  })
-
-  console.log('Created nodes:', nodes.length, 'edges:', edges.length)
-
-  return { nodes, edges }
 }

--- a/client/src/pages/RoadmapPage.tsx
+++ b/client/src/pages/RoadmapPage.tsx
@@ -306,17 +306,15 @@ interface CategoryGroup {
 }
 
 export default function RoadmapPage() {
-  const [completedItems, setCompletedItems] = useState<Set<string>>(new Set())
-  const [showSidebar, setShowSidebar] = useState(true)
-  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
-
-  // Load from localStorage on mount
-  useEffect(() => {
+  const [completedItems, setCompletedItems] = useState<Set<string>>(() => {
     try {
       const saved = localStorage.getItem('dl-roadmap-completed')
-      if (saved) setCompletedItems(new Set(JSON.parse(saved) as string[]))
+      if (saved) return new Set(JSON.parse(saved) as string[])
     } catch { /* ignore */ }
-  }, [])
+    return new Set()
+  })
+  const [showSidebar, setShowSidebar] = useState(true)
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
 
   // Persist to localStorage on change
   useEffect(() => {


### PR DESCRIPTION
## Mindmap visualization overhaul

Redesigns the interactive deep learning mindmap from a basic radial layout into a polished, organized bidirectional mindmap with a "bring the tree to life" completion mechanic.

### What changed

**Layout**
- Replaced the overlapping radial algorithm with a **bidirectional tree layout** — branches radiate left and right from a central root node, matching the classic mindmap style
- Uses a leaf-count algorithm to allocate vertical space per subtree, guaranteeing zero node overlaps by construction
- Layout is computed once on mount (stable `useMemo`) instead of re-running on every completion toggle

**Visual hierarchy**
- Three distinct node types: gradient pill root, colored solid-pill category nodes (level 1), and compact topic cards (level 2+)
- Expanded color palette from 5 to 10 unique colors — one per top-level branch
- Bezier curve edges with no arrowheads, graded thickness (4px → 2.5px → 1.5px) and branch-matched colors, giving an organic mindmap feel
- Left-side node handles and text alignment are mirrored so curves arc naturally toward the center

**"Bring the tree to life" mechanic**
- All nodes start greyed out (`grayscale(100%)`, 45% opacity) — the map feels dormant until you begin
- Completing a topic node smoothly transitions it to full color with a soft category-colored glow
- Category nodes progressively saturate and glow as their subtree completion ratio increases — from fully grey at 0% to fully vivid at 100%
- Edges light up to full opacity the moment any node in their target subtree is completed, so learning paths illuminate branch by branch
- All transitions are CSS-animated (0.6–0.7s ease) for a natural, organic feel
- MiniMap mirrors the grey/color state — completed branches show their category color, untouched areas stay grey

**Sidebar**
- Replaced flat topic list with collapsible sections grouped by category
- Each section shows a colored dot indicator, per-category progress bar, and topic count
- Overall progress bar in the sidebar header

**Persistence & bug fixes**
- Completion state saved to `localStorage` and restored via a lazy `useState` initializer — survives page refresh with no race condition
- Fixed a bug where the save `useEffect` ran on initial mount before the load effect's state update, overwriting `localStorage` with an empty array (especially problematic in React StrictMode)
- Removed debug `useEffect` blocks and all `console.log` calls
- Fixed duplicate node entry in `mindmap-data.ts` (`Regularization Techniques` appeared twice)

### Test plan
- [x] Open the roadmap page and confirm the mindmap branches left and right from the center
- [x] Zoom in/out — verify no node overlaps at any level
- [x] Confirm all nodes start greyed out on a fresh session
- [x] Click topic nodes and sidebar checkboxes — confirm nodes and edges animate to full color on completion
- [x] Complete all topics in a category — confirm the category pill fully lights up with a glow
- [x] Refresh the page — confirm completed topics and their visual state persist
- [x] Collapse/expand category sections in the sidebar
